### PR TITLE
disallow names of node core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,27 @@ npm install validate-npm-package-name --save
 ## Usage
 
 ```js
-var valid = require("validate-npm-package-name")
+var validate = require("validate-npm-package-name")
+
+// regular
 
 validate("some-package")  // => {valid: true}
 validate("example.com")   // => {valid: true}
 validate("under_score")   // => {valid: true}
 validate("123numeric")    // => {valid: true}
 validate("crazy!")        // => {valid: true}
+
+// scoped
+
 validate("@npm/thingy")   // => {valid: true}
 validate("@jane/foo.js")  // => {valid: true}
+
+// valid, but reserved by node core
+
+validate("http")          // => {valid: true, warnings:["http is a node core module name"]}
+validate("url")           // => {valid: true, warnings:["url is a node core module name"]}
+
+// invalid
 
 validate("")              // => {valid: false, errors:["name length must be greater than zero"]}
 validate("ca$h")          // => {valid: false, errors:["name can only contain URL-friendly characters"]}
@@ -45,7 +57,7 @@ npm test
 
 ## Dependencies
 
-None
+- [builtins](https://github.com/juliangruber/builtins): List of node.js builtin modules
 
 ## Dev Dependencies
 

--- a/example.js
+++ b/example.js
@@ -1,12 +1,24 @@
-var valid = require("./")
+var validate = require("./")
+
+// regular
 
 validate("some-package")  // => {valid: true}
 validate("example.com")   // => {valid: true}
 validate("under_score")   // => {valid: true}
 validate("123numeric")    // => {valid: true}
 validate("crazy!")        // => {valid: true}
+
+// scoped
+
 validate("@npm/thingy")   // => {valid: true}
 validate("@jane/foo.js")  // => {valid: true}
+
+// valid, but reserved by node core
+
+validate("http")          // => {valid: true, warnings:["http is a node core module name"]}
+validate("url")           // => {valid: true, warnings:["url is a node core module name"]}
+
+// invalid
 
 validate("")              // => {valid: false, errors:["name length must be greater than zero"]}
 validate("ca$h")          // => {valid: false, errors:["name can only contain URL-friendly characters"]}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var scopedPackagePattern = new RegExp("^(?:@([^/]+?)[/])?([^/]+?)$");
-var nodeCoreModuleNames = require("node-core-module-names")
+var builtins = require("builtins")
 var blacklist = [
   "node_modules",
   "favicon.ico"
@@ -63,9 +63,9 @@ var validate = module.exports = function(name, options) {
 
   // Disallow core module names
   // http, events, util, domain, cluster, etc
-  nodeCoreModuleNames.forEach(function(nodeCoreModule){
-    if (name.toLowerCase() === nodeCoreModule) {
-      errors.push(nodeCoreModule + " is a Node.js core module name")
+  builtins.forEach(function(builtin){
+    if (name.toLowerCase() === builtin) {
+      errors.push(builtin + " is a Node.js core module name")
     }
   })
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var scopedPackagePattern = new RegExp("^(?:@([^/]+?)[/])?([^/]+?)$");
+var nodeCoreModuleNames = require("node-core-module-names")
 var blacklist = [
   "node_modules",
   "favicon.ico"
@@ -53,9 +54,18 @@ var validate = module.exports = function(name, options) {
     errors.push("name must be lowercase")
   }
 
+  // No funny business
   blacklist.forEach(function(blacklistedName){
     if (name.toLowerCase() === blacklistedName) {
       errors.push(blacklistedName + " is a blacklisted name")
+    }
+  })
+
+  // Disallow core module names
+  // http, events, util, domain, cluster, etc
+  nodeCoreModuleNames.forEach(function(nodeCoreModule){
+    if (name.toLowerCase() === nodeCoreModule) {
+      errors.push(nodeCoreModule + " is a Node.js core module name")
     }
   })
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var blacklist = [
 
 var validate = module.exports = function(name, options) {
 
+  var warnings = []
   var errors = []
 
   if (!options) {
@@ -17,17 +18,17 @@ var validate = module.exports = function(name, options) {
 
   if (name === null) {
     errors.push("name cannot be null")
-    return done(errors)
+    return done(warnings, errors)
   }
 
   if (name === undefined) {
     errors.push("name cannot be undefined")
-    return done(errors)
+    return done(warnings, errors)
   }
 
   if (typeof name !== "string") {
     errors.push("name must be a string")
-    return done(errors)
+    return done(warnings, errors)
   }
 
   if (!name.length) {
@@ -61,11 +62,11 @@ var validate = module.exports = function(name, options) {
     }
   })
 
-  // Disallow core module names
+  // Warn on core module names
   // http, events, util, domain, cluster, etc
   builtins.forEach(function(builtin){
     if (name.toLowerCase() === builtin) {
-      errors.push(builtin + " is a Node.js core module name")
+      warnings.push(builtin + " is a node core module name")
     }
   })
 
@@ -77,23 +78,26 @@ var validate = module.exports = function(name, options) {
       var user = nameMatch[1]
       var pkg = nameMatch[2]
       if (encodeURIComponent(user) === user && encodeURIComponent(pkg) === pkg) {
-        return done(errors)
+        return done(warnings, errors)
       }
     }
 
     errors.push("name can only contain URL-friendly characters")
   }
 
-  return done(errors)
+  return done(warnings, errors)
 
 }
 
 validate.scopedPackagePattern = scopedPackagePattern
 
-var done = function (errors) {
-  if (errors.length) {
-    return {valid: false, errors: errors}
-  } else {
-    return {valid: true}
+var done = function (warnings, errors) {
+  var result = {
+    valid: errors.length === 0,
+    warnings: warnings,
+    errors: errors
   }
+  if (!result.warnings.length) delete result.warnings
+  if (!result.errors.length) delete result.errors
+  return result
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "node-core-module-names": "^1.0.0"
+    "builtins": "0.0.7"
   },
   "devDependencies": {
     "tap": "^0.4.13"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node-core-module-names": "^1.0.0"
+  },
   "devDependencies": {
     "tap": "^0.4.13"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -57,6 +57,10 @@ test("validate-npm-package-name", function (t) {
     valid: false,
     errors: ["favicon.ico is a blacklisted name"]})
 
+  t.deepEqual(valid("http"), {
+    valid: false,
+    errors: ["http is a Node.js core module name"]})
+
   // Legacy Mixed-Case
 
   t.deepEqual(valid("CAPITAL-LETTERS", {allowMixedCase: true}), {valid: true})

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var valid = require("..")
+var validate = require("..")
 var test = require("tap").test
 var path = require("path")
 var fs = require("fs")
@@ -7,75 +7,75 @@ test("validate-npm-package-name", function (t) {
 
   // Traditional
 
-  t.deepEqual(valid("some-package"), {valid: true})
-  t.deepEqual(valid("example.com"), {valid: true})
-  t.deepEqual(valid("under_score"), {valid: true})
-  t.deepEqual(valid("period.js"), {valid: true})
-  t.deepEqual(valid("123numeric"), {valid: true})
-  t.deepEqual(valid("crazy!"), {valid: true})
+  t.deepEqual(validate("some-package"), {valid: true})
+  t.deepEqual(validate("example.com"), {valid: true})
+  t.deepEqual(validate("under_score"), {valid: true})
+  t.deepEqual(validate("period.js"), {valid: true})
+  t.deepEqual(validate("123numeric"), {valid: true})
+  t.deepEqual(validate("crazy!"), {valid: true})
 
   // Scoped (npm 2+)
 
-  t.deepEqual(valid("@npm/thingy"), {valid: true})
-  t.deepEqual(valid("@npm-zors/money!time.js"), {valid: true})
+  t.deepEqual(validate("@npm/thingy"), {valid: true})
+  t.deepEqual(validate("@npm-zors/money!time.js"), {valid: true})
 
   // Invalid
 
-  t.deepEqual(valid(""), {
+  t.deepEqual(validate(""), {
     valid: false,
     errors: ["name length must be greater than zero"]})
 
-  t.deepEqual(valid(""), {
+  t.deepEqual(validate(""), {
     valid: false,
     errors: ["name length must be greater than zero"]})
 
-  t.deepEqual(valid(".start-with-period"), {
+  t.deepEqual(validate(".start-with-period"), {
     valid: false,
     errors: ["name cannot start with a period"]})
 
-  t.deepEqual(valid("_start-with-underscore"), {
+  t.deepEqual(validate("_start-with-underscore"), {
     valid: false,
     errors: ["name cannot start with an underscore"]})
 
-  t.deepEqual(valid("contain:colons"), {
+  t.deepEqual(validate("contain:colons"), {
     valid: false,
     errors: ["name can only contain URL-friendly characters"]})
 
-  t.deepEqual(valid("1234567890123456789012345678901234567890-more-than-fifty"), {
+  t.deepEqual(validate("1234567890123456789012345678901234567890-more-than-fifty"), {
     valid: false,
     errors: ["name cannot be longer than 50 characters"]})
 
-  t.deepEqual(valid(" leading-space"), {
+  t.deepEqual(validate(" leading-space"), {
     valid: false,
     errors: ["name cannot contain leading or trailing spaces", "name can only contain URL-friendly characters"]})
 
-  t.deepEqual(valid("trailing-space "), {
+  t.deepEqual(validate("trailing-space "), {
     valid: false,
     errors: ["name cannot contain leading or trailing spaces", "name can only contain URL-friendly characters"]})
 
-  t.deepEqual(valid("s/l/a/s/h/e/s"), {
+  t.deepEqual(validate("s/l/a/s/h/e/s"), {
     valid: false,
     errors: ["name can only contain URL-friendly characters"]})
 
-  t.deepEqual(valid("node_modules"), {
+  t.deepEqual(validate("node_modules"), {
     valid: false,
     errors: ["node_modules is a blacklisted name"]})
 
-  t.deepEqual(valid("favicon.ico"), {
+  t.deepEqual(validate("favicon.ico"), {
     valid: false,
     errors: ["favicon.ico is a blacklisted name"]})
 
   // Sketchy
 
-  t.deepEqual(valid("http"), {
+  t.deepEqual(validate("http"), {
     valid: true,
     warnings: ["http is a node core module name"]})
 
   // Legacy Mixed-Case
 
-  t.deepEqual(valid("CAPITAL-LETTERS", {allowMixedCase: true}), {valid: true})
+  t.deepEqual(validate("CAPITAL-LETTERS", {allowMixedCase: true}), {valid: true})
 
-  t.deepEqual(valid("CAPITAL-LETTERS"), {
+  t.deepEqual(validate("CAPITAL-LETTERS"), {
     valid: false,
     errors: ["name must be lowercase"]})
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,14 +4,22 @@ var path = require("path")
 var fs = require("fs")
 
 test("validate-npm-package-name", function (t) {
+
+  // Traditional
+
   t.deepEqual(valid("some-package"), {valid: true})
   t.deepEqual(valid("example.com"), {valid: true})
   t.deepEqual(valid("under_score"), {valid: true})
   t.deepEqual(valid("period.js"), {valid: true})
   t.deepEqual(valid("123numeric"), {valid: true})
   t.deepEqual(valid("crazy!"), {valid: true})
+
+  // Scoped (npm 2+)
+
   t.deepEqual(valid("@npm/thingy"), {valid: true})
   t.deepEqual(valid("@npm-zors/money!time.js"), {valid: true})
+
+  // Invalid
 
   t.deepEqual(valid(""), {
     valid: false,
@@ -57,9 +65,11 @@ test("validate-npm-package-name", function (t) {
     valid: false,
     errors: ["favicon.ico is a blacklisted name"]})
 
+  // Sketchy
+
   t.deepEqual(valid("http"), {
-    valid: false,
-    errors: ["http is a Node.js core module name"]})
+    valid: true,
+    warnings: ["http is a node core module name"]})
 
   // Legacy Mixed-Case
 
@@ -68,9 +78,6 @@ test("validate-npm-package-name", function (t) {
   t.deepEqual(valid("CAPITAL-LETTERS"), {
     valid: false,
     errors: ["name must be lowercase"]})
-
-
-
 
   t.end()
 })


### PR DESCRIPTION
For the consideration of @othiym23 and @iarna, I present a possible implementation of #1.

Twas a good excuse to write [node-core-module-names](npm.im/node-core-module-names), my smallest npm package yet.

cc @robertkowalski