### PR TITLE
bump max name length from 50 to 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ a change in the value of `validForNewPackages` property, and a warnings array
 will be present:
 
 ```js
-validate("cRaZY-paCkAgE-with-mixed-case-and-more-than-fifty-characters")
+validate("cRaZY-paCkAgE-with-mixed-case-and-more-than-128-characters----------------------------------------------------------------------")
 ```
 
 returns:
@@ -69,7 +69,7 @@ returns:
   validForOldPackages: true,
   warnings: [
     "name can no longer contain capital letters",
-    "name can no longer contain more than 50 characters"
+    "name can no longer contain more than 128 characters"
   ]
 }
 ```

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ var validate = module.exports = function(name) {
   })
 
   // really-long-package-names-------------------------------such--length-----many---wow
-  if (name.length > 50) {
-    warnings.push("name can no longer contain more than 50 characters")
+  if (name.length > 128) {
+    warnings.push("name can no longer contain more than 128 characters")
   }
 
   // mIxeD CaSe nAMEs

--- a/test/index.js
+++ b/test/index.js
@@ -80,10 +80,10 @@ test("validate-npm-package-name", function (t) {
 
   // Long Package Names
 
-  t.deepEqual(validate("1234567890123456789012345678901234567890-more-than-fifty"), {
+  t.deepEqual(validate("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"), {
     validForNewPackages: false,
     validForOldPackages: true,
-    warnings: ["name can no longer contain more than 50 characters"]
+    warnings: ["name can no longer contain more than 128 characters"]
   })
 
   // Legacy Mixed-Case


### PR DESCRIPTION
Addresses https://github.com/npm/npm/issues/8077 and https://github.com/npm/validate-npm-package-name/issues/4

I think 128 characters is a bit generous, but maybe it's okay to be generous.

cc @wojciak @smikes @othiym23 @bcoe 