### PR TITLE
BREAKING CHANGE: Invalidate special chars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - '0.10'
+  - '4'
+  - '6'

--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ var validate = module.exports = function(name) {
     warnings.push("name can no longer contain capital letters")
   }
 
+  if (/[~'!()*]/.test(name.split('/').slice(-1)[0])) {
+    warnings.push('name can no longer contain special characters ("~\'!()*")')
+  }
+
   if (encodeURIComponent(name) !== name) {
 
     // Maybe it's a scoped package name, like @user/package

--- a/index.js
+++ b/index.js
@@ -1,71 +1,72 @@
-var scopedPackagePattern = new RegExp("^(?:@([^/]+?)[/])?([^/]+?)$");
-var builtins = require("builtins")
+'use strict'
+
+var scopedPackagePattern = new RegExp('^(?:@([^/]+?)[/])?([^/]+?)$')
+var builtins = require('builtins')
 var blacklist = [
-  "node_modules",
-  "favicon.ico"
-];
+  'node_modules',
+  'favicon.ico'
+]
 
-var validate = module.exports = function(name) {
-
+var validate = module.exports = function (name) {
   var warnings = []
   var errors = []
 
   if (name === null) {
-    errors.push("name cannot be null")
+    errors.push('name cannot be null')
     return done(warnings, errors)
   }
 
   if (name === undefined) {
-    errors.push("name cannot be undefined")
+    errors.push('name cannot be undefined')
     return done(warnings, errors)
   }
 
-  if (typeof name !== "string") {
-    errors.push("name must be a string")
+  if (typeof name !== 'string') {
+    errors.push('name must be a string')
     return done(warnings, errors)
   }
 
   if (!name.length) {
-    errors.push("name length must be greater than zero")
+    errors.push('name length must be greater than zero')
   }
 
   if (name.match(/^\./)) {
-    errors.push("name cannot start with a period")
+    errors.push('name cannot start with a period')
   }
 
   if (name.match(/^_/)) {
-    errors.push("name cannot start with an underscore")
+    errors.push('name cannot start with an underscore')
   }
 
   if (name.trim() !== name) {
-    errors.push("name cannot contain leading or trailing spaces")
+    errors.push('name cannot contain leading or trailing spaces')
   }
 
   // No funny business
-  blacklist.forEach(function(blacklistedName){
+  blacklist.forEach(function (blacklistedName) {
     if (name.toLowerCase() === blacklistedName) {
-      errors.push(blacklistedName + " is a blacklisted name")
+      errors.push(blacklistedName + ' is a blacklisted name')
     }
   })
 
   // Generate warnings for stuff that used to be allowed
 
   // core module names like http, events, util, etc
-  builtins.forEach(function(builtin){
+  builtins.forEach(function (builtin) {
     if (name.toLowerCase() === builtin) {
-      warnings.push(builtin + " is a core module name")
+      warnings.push(builtin + ' is a core module name')
     }
   })
 
   // really-long-package-names-------------------------------such--length-----many---wow
   // the thisisareallyreallylongpackagenameitshouldpublishdowenowhavealimittothelengthofpackagenames-poch.
   if (name.length > 214) {
-    warnings.push("name can no longer contain more than 214 characters")
+    warnings.push('name can no longer contain more than 214 characters')
   }
 
   // mIxeD CaSe nAMEs
   if (name.toLowerCase() !== name) {
-    warnings.push("name can no longer contain capital letters")
+    warnings.push('name can no longer contain capital letters')
   }
 
   if (/[~'!()*]/.test(name.split('/').slice(-1)[0])) {
@@ -73,7 +74,6 @@ var validate = module.exports = function(name) {
   }
 
   if (encodeURIComponent(name) !== name) {
-
     // Maybe it's a scoped package name, like @user/package
     var nameMatch = name.match(scopedPackagePattern)
     if (nameMatch) {
@@ -84,11 +84,10 @@ var validate = module.exports = function(name) {
       }
     }
 
-    errors.push("name can only contain URL-friendly characters")
+    errors.push('name can only contain URL-friendly characters')
   }
 
   return done(warnings, errors)
-
 }
 
 validate.scopedPackagePattern = scopedPackagePattern

--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
     "test": "test"
   },
   "dependencies": {
-    "builtins": "0.0.7"
+    "builtins": "^1.0.3"
   },
   "devDependencies": {
-    "tap": "^0.4.13"
+    "standard": "^8.6.0",
+    "tap": "^10.0.0"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "cov:test": "TAP_FLAGS='--cov' npm run test:code",
+    "test:code": "tap ${TAP_FLAGS:-'--'} test/*.js",
+    "test:style": "standard",
+    "test": "npm run test:code && npm run test:style"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -1,106 +1,109 @@
-var validate = require("..")
-var test = require("tap").test
-var path = require("path")
-var fs = require("fs")
+'use strict'
 
-test("validate-npm-package-name", function (t) {
+var validate = require('..')
+var test = require('tap').test
 
+test('validate-npm-package-name', function (t) {
   // Traditional
 
-  t.deepEqual(validate("some-package"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("example.com"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("under_score"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("period.js"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("123numeric"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("crazy!"), {validForNewPackages: false, validForOldPackages: true, warnings: [
-    'name can no longer contain special characters ("~\'!()*")'
-  ]})
+  t.deepEqual(validate('some-package'), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate('example.com'), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate('under_score'), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate('period.js'), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate('123numeric'), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate('crazy!'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['name can no longer contain special characters ("~\'!()*")']
+  })
 
   // Scoped (npm 2+)
 
-  t.deepEqual(validate("@npm/thingy"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("@npm-zors/money!time.js"), {validForNewPackages: false, validForOldPackages: true, warnings: [
-    'name can no longer contain special characters ("~\'!()*")'
-  ]})
+  t.deepEqual(validate('@npm/thingy'), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate('@npm-zors/money!time.js'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['name can no longer contain special characters ("~\'!()*")']
+  })
 
   // Invalid
 
-  t.deepEqual(validate(""), {
+  t.deepEqual(validate(''), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name length must be greater than zero"]})
+    errors: ['name length must be greater than zero']})
 
-  t.deepEqual(validate(""), {
+  t.deepEqual(validate(''), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name length must be greater than zero"]})
+    errors: ['name length must be greater than zero']})
 
-  t.deepEqual(validate(".start-with-period"), {
+  t.deepEqual(validate('.start-with-period'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name cannot start with a period"]})
+    errors: ['name cannot start with a period']})
 
-  t.deepEqual(validate("_start-with-underscore"), {
+  t.deepEqual(validate('_start-with-underscore'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name cannot start with an underscore"]})
+    errors: ['name cannot start with an underscore']})
 
-  t.deepEqual(validate("contain:colons"), {
+  t.deepEqual(validate('contain:colons'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name can only contain URL-friendly characters"]})
+    errors: ['name can only contain URL-friendly characters']})
 
-  t.deepEqual(validate(" leading-space"), {
+  t.deepEqual(validate(' leading-space'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name cannot contain leading or trailing spaces", "name can only contain URL-friendly characters"]})
+    errors: ['name cannot contain leading or trailing spaces', 'name can only contain URL-friendly characters']})
 
-  t.deepEqual(validate("trailing-space "), {
+  t.deepEqual(validate('trailing-space '), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name cannot contain leading or trailing spaces", "name can only contain URL-friendly characters"]})
+    errors: ['name cannot contain leading or trailing spaces', 'name can only contain URL-friendly characters']})
 
-  t.deepEqual(validate("s/l/a/s/h/e/s"), {
+  t.deepEqual(validate('s/l/a/s/h/e/s'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["name can only contain URL-friendly characters"]})
+    errors: ['name can only contain URL-friendly characters']})
 
-  t.deepEqual(validate("node_modules"), {
+  t.deepEqual(validate('node_modules'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["node_modules is a blacklisted name"]})
+    errors: ['node_modules is a blacklisted name']})
 
-  t.deepEqual(validate("favicon.ico"), {
+  t.deepEqual(validate('favicon.ico'), {
     validForNewPackages: false,
     validForOldPackages: false,
-    errors: ["favicon.ico is a blacklisted name"]})
+    errors: ['favicon.ico is a blacklisted name']})
 
   // Node/IO Core
 
-  t.deepEqual(validate("http"), {
+  t.deepEqual(validate('http'), {
     validForNewPackages: false,
     validForOldPackages: true,
-    warnings: ["http is a core module name"]})
+    warnings: ['http is a core module name']})
 
   // Long Package Names
 
-  t.deepEqual(validate("ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou-"), {
+  t.deepEqual(validate('ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou-'), {
     validForNewPackages: false,
     validForOldPackages: true,
-    warnings: ["name can no longer contain more than 214 characters"]
+    warnings: ['name can no longer contain more than 214 characters']
   })
 
-  t.deepEqual(validate("ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou"), {
+  t.deepEqual(validate('ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou'), {
     validForNewPackages: true,
     validForOldPackages: true
   })
 
   // Legacy Mixed-Case
 
-  t.deepEqual(validate("CAPITAL-LETTERS"), {
+  t.deepEqual(validate('CAPITAL-LETTERS'), {
     validForNewPackages: false,
     validForOldPackages: true,
-    warnings: ["name can no longer contain capital letters"]})
+    warnings: ['name can no longer contain capital letters']})
 
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -12,12 +12,16 @@ test("validate-npm-package-name", function (t) {
   t.deepEqual(validate("under_score"), {validForNewPackages: true, validForOldPackages: true})
   t.deepEqual(validate("period.js"), {validForNewPackages: true, validForOldPackages: true})
   t.deepEqual(validate("123numeric"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("crazy!"), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate("crazy!"), {validForNewPackages: false, validForOldPackages: true, warnings: [
+    'name can no longer contain special characters ("~\'!()*")'
+  ]})
 
   // Scoped (npm 2+)
 
   t.deepEqual(validate("@npm/thingy"), {validForNewPackages: true, validForOldPackages: true})
-  t.deepEqual(validate("@npm-zors/money!time.js"), {validForNewPackages: true, validForOldPackages: true})
+  t.deepEqual(validate("@npm-zors/money!time.js"), {validForNewPackages: false, validForOldPackages: true, warnings: [
+    'name can no longer contain special characters ("~\'!()*")'
+  ]})
 
   // Invalid
 


### PR DESCRIPTION
No longer allow `~!'()*` in package names in any position (Surprise, they're url-safe!)

The [first commit](https://github.com/npm/validate-npm-package-name/commit/afc9c14787a0f774ea4e2a8ea9eaf40a5d87f2bc) contains the relevant change; the [second commit](https://github.com/npm/validate-npm-package-name/commit/48f145f89bae4d1543ac1eecd594c6a89e01ea95) upgrades the `builtins` & `tap` deps; the final commit (noisily) `standard`-formats the repo.