### PR TITLE
Remove inconsistency regarding whether '!' is disallowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Below is a list of rules that valid `npm` package name should conform to.
 - package name must *not* contain any non-url-safe characters (since name ends up being part of a URL)
 - package name should not start with `.` or `_`
 - package name should *not* contain any leading or trailing spaces
-- package name should *not* contain any of the following characters: `~)('!*`
+- package name should *not* contain any of the following characters: `~)('*`
 - package name *cannot* be the same as a node.js/io.js core module nor a reserved/blacklisted name. For example, the following names are invalid:
     + http
     + stream


### PR DESCRIPTION
README says that `!` should not be allowed, but has an example below of a valid package name with `!` in it