### PR TITLE
Update `builtins`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var scopedPackagePattern = new RegExp('^(?:@([^/]+?)[/])?([^/]+?)$')
-var builtins = require('builtins')
+var builtins = require('builtins')()
 var blacklist = [
   'node_modules',
   'favicon.ico'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "builtins": "^1.0.3"
+    "builtins": "^2.0.0"
   },
   "devDependencies": {
     "standard": "^8.6.0",


### PR DESCRIPTION
- npm: Update `builtins`
- .gitignore: Avoid adding `package-lock.json` to repo

(Besides getting the latest builtins for the detected Node version, this update has the benefit for me of working around an apparent Rollup bug processing JSON-as-commonjs, so I can use your package in the browser.)