### PR TITLE
Forbid names containing 'download'

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var blacklist = [
   'favicon.ico'
 ]
 var blacklistRegex = [
-  /download/
+  /(^|\W)download($|\W)/
 ]
 
 var validate = module.exports = function (name) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var blacklist = [
   'node_modules',
   'favicon.ico'
 ]
+var blacklistRegex = [
+  /download/
+]
 
 var validate = module.exports = function (name) {
   var warnings = []
@@ -46,6 +49,11 @@ var validate = module.exports = function (name) {
   blacklist.forEach(function (blacklistedName) {
     if (name.toLowerCase() === blacklistedName) {
       errors.push(blacklistedName + ' is a blacklisted name')
+    }
+  })
+  blacklistRegex.forEach(function (blacklistedRegex) {
+    if (blacklistedRegex.test(name.toLowerCase())) {
+      warnings.push('names matching ' + blacklistedRegex + ' are no longer allowed')
     }
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,24 @@ test('validate-npm-package-name', function (t) {
   t.deepEqual(validate('download-file-async'), {
     validForNewPackages: false,
     validForOldPackages: true,
-    warnings: ['names matching /download/ are no longer allowed']
+    warnings: ['names matching /(^|\\W)download($|\\W)/ are no longer allowed']
+  })
+
+  t.deepEqual(validate('forbid-download-everywhere'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['names matching /(^|\\W)download($|\\W)/ are no longer allowed']
+  })
+
+  t.deepEqual(validate('forbid-download'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['names matching /(^|\\W)download($|\\W)/ are no longer allowed']
+  })
+
+  t.deepEqual(validate('node-downloader-helper'), {
+    validForNewPackages: true,
+    validForOldPackages: true
   })
 
   // Node/IO Core

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,12 @@ test('validate-npm-package-name', function (t) {
     validForOldPackages: false,
     errors: ['favicon.ico is a blacklisted name']})
 
+  t.deepEqual(validate('download-file-async'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['names matching /download/ are no longer allowed']
+  })
+
   // Node/IO Core
 
   t.deepEqual(validate('http'), {


### PR DESCRIPTION
Do this by adding a list of regexes. These are warnings since old, pre-spam filter packages are allowed to contain the word 'download'.