### PR TITLE
docs: update misleading naming rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Below is a list of rules that valid `npm` package name should conform to.
 - package name *can* consist of hyphens
 - package name must *not* contain any non-url-safe characters (since name ends up being part of a URL)
 - package name should not start with `.` or `_`
-- package name should *not* any spaces
+- package name should *not* contain any spaces
 - package name should *not* contain any of the following characters: `~)('!*`
 - package name *cannot* be the same as a node.js/io.js core module nor a reserved/blacklisted name. For example, the following names are invalid:
     + http

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Below is a list of rules that valid `npm` package name should conform to.
 - package name *can* consist of hyphens
 - package name must *not* contain any non-url-safe characters (since name ends up being part of a URL)
 - package name should not start with `.` or `_`
-- package name should *not* contain any leading or trailing spaces
+- package name should *not* any spaces
 - package name should *not* contain any of the following characters: `~)('!*`
 - package name *cannot* be the same as a node.js/io.js core module nor a reserved/blacklisted name. For example, the following names are invalid:
     + http


### PR DESCRIPTION
Fix https://github.com/npm/validate-npm-package-name/issues/20.

# What / Why

This rule in readme is misleading:
> package name should *not* contain any leading or trailing spaces

It should be replaced by:
> package name should *not* contain any spaces

Since spaces are not allowed at all (and it's a common issue)

## References
  * Related to https://github.com/npm/validate-npm-package-name/issues/20
  * Closes https://github.com/npm/validate-npm-package-name/issues/20
