### PR TITLE
chore: include only the main file in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.0.0",
   "description": "Give me a string and I'll tell you if it's a valid npm package name",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Currently the npm package includes useless files:

```
.npmignore
.nyc_output
.travis.yml
index.js
LICENSE
package.json
README.md
test
.nyc_output\aa4ee25ac41a9c3c7ee37ce965e6d1ac.json
.nyc_output\bb918173e62b9517f55b630902d07ef4.json
test\index.js
```

After:

```
LICENSE
README.md
index.js
package.json
```
## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
