### PR TITLE
Update Builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ var validate = module.exports = function (name) {
   // Generate warnings for stuff that used to be allowed
 
   // core module names like http, events, util, etc
-  builtins.forEach(function (builtin) {
+  builtins({ version: '*' }).forEach(function (builtin) {
     if (name.toLowerCase() === builtin) {
       warnings.push(builtin + ' is a core module name')
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "builtins": "^1.0.3"
+    "builtins": "^5.0.0"
   },
   "devDependencies": {
     "standard": "^8.6.0",

--- a/test/index.js
+++ b/test/index.js
@@ -85,6 +85,11 @@ test('validate-npm-package-name', function (t) {
     validForOldPackages: true,
     warnings: ['http is a core module name']})
 
+  t.deepEqual(validate('process'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['process is a core module name']})
+
   // Long Package Names
 
   t.deepEqual(validate('ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou-'), {


### PR DESCRIPTION
This PR updates the version of the `builtins` module to `5.0.0` in order to get the most up to date list of builtin modules. It's configured to warn on modules that have been a builtin on any version of Node.  

## References

Recreates https://github.com/npm/validate-npm-package-name/pull/21
