### PR TITLE
fix: remove validate.scopedPackagePattern

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var blacklist = [
   'favicon.ico',
 ]
 
-var validate = module.exports = function (name) {
+function validate (name) {
   var warnings = []
   var errors = []
 
@@ -88,8 +88,6 @@ var validate = module.exports = function (name) {
   return done(warnings, errors)
 }
 
-validate.scopedPackagePattern = scopedPackagePattern
-
 var done = function (warnings, errors) {
   var result = {
     validForNewPackages: errors.length === 0 && warnings.length === 0,
@@ -105,3 +103,5 @@ var done = function (warnings, errors) {
   }
   return result
 }
+
+module.exports = validate


### PR DESCRIPTION
BREAKING CHANGE: scopedPackagePattern is no longer exported from this
module.

Closes https://github.com/npm/validate-npm-package-name/issues/35