### PR TITLE
chore: update tap coverage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
     "version": "4.11.4"
   },
   "tap": {
-    "statements": 88,
-    "branches": 92,
-    "lines": 88,
     "nyc-arg": [
       "--exclude",
       "tap-snapshots/**"


### PR DESCRIPTION
We're at 100 now, no config needed anymore
