### PR TITLE
deps: replace `builtins` dependency with Node.js `module.builtinModules`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict'
+const { builtinModules: builtins } = require('module')
 
 var scopedPackagePattern = new RegExp('^(?:@([^/]+?)[/])?([^/]+?)$')
-var builtins = require('builtins')
 var blacklist = [
   'node_modules',
   'favicon.ico',
@@ -52,11 +52,9 @@ function validate (name) {
   // Generate warnings for stuff that used to be allowed
 
   // core module names like http, events, util, etc
-  builtins({ version: '*' }).forEach(function (builtin) {
-    if (name.toLowerCase() === builtin) {
-      warnings.push(builtin + ' is a core module name')
-    }
-  })
+  if (builtins.includes(name.toLowerCase())) {
+    warnings.push(name + ' is a core module name')
+  }
 
   if (name.length > 214) {
     warnings.push('name can no longer contain more than 214 characters')

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "builtins": "^5.0.0"
-  },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
     "@npmcli/template-oss": "4.21.3",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR replaces the `builtins` dependency with the Node.js internal `module.builtinModules` property/constant. This change does not break any functionality of this package.

I am aware of this comment in the CONTRIBUTING.md file:

> It should be noted that our team does not accept third-party dependency updates/PRs.  If you submit a PR trying to update our dependencies we will close it with or without a reference to these contribution guidelines.

In my defense, this PR does not add a third-party dependency but removes one so I think it should be considered.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
