### PR TITLE
fix: adding additional validation for scoped packages that begin with one or more `.`

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,9 @@ on:
     # "At 08:00 UTC (01:00 PT) on Monday" https://crontab.guru/#0_8_*_*_1
     - cron: "0 8 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     name: Audit Dependencies

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -18,6 +18,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   lint-all:
     name: Lint All

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
     # "At 09:00 UTC (02:00 PT) on Monday" https://crontab.guru/#0_9_*_*_1
     - cron: "0 9 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,9 @@ on:
     # "At 10:00 UTC (03:00 PT) on Monday" https://crontab.guru/#0_10_*_*_1
     - cron: "0 10 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     name: Lint Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -19,6 +19,10 @@ on:
       PUBLISH_TOKEN:
         required: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,7 @@ jobs:
     if: needs.release.outputs.releases
     uses: ./.github/workflows/release-integration.yml
     permissions:
+      contents: read
       id-token: write
     secrets:
       PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function validate (name) {
     errors.push('name length must be greater than zero')
   }
 
-  if (name.match(/^\./)) {
+  if (name.startsWith('.')) {
     errors.push('name cannot start with a period')
   }
 
@@ -75,6 +75,11 @@ function validate (name) {
     if (nameMatch) {
       var user = nameMatch[1]
       var pkg = nameMatch[2]
+
+      if (pkg.startsWith('.')) {
+        errors.push('name cannot start with a period')
+      }
+
       if (encodeURIComponent(user) === user && encodeURIComponent(pkg) === pkg) {
         return done(warnings, errors)
       }

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,21 @@ test('validate-npm-package-name', function (t) {
     validForOldPackages: false,
     errors: ['name cannot start with a period'] })
 
+  t.same(validate('@npm/.'), {
+    validForNewPackages: false,
+    validForOldPackages: false,
+    errors: ['name cannot start with a period'] })
+
+  t.same(validate('@npm/..'), {
+    validForNewPackages: false,
+    validForOldPackages: false,
+    errors: ['name cannot start with a period'] })
+
+  t.same(validate('@npm/.package'), {
+    validForNewPackages: false,
+    validForOldPackages: false,
+    errors: ['name cannot start with a period'] })
+
   t.same(validate('_start-with-underscore'), {
     validForNewPackages: false,
     validForOldPackages: false,


### PR DESCRIPTION
Adding additional validation and tests to cover scoped packages to enforce rule: 
> package name should not start with . or _

Examples include 
- `@npm/..`
- `@npm/.`
- `@npm/.something`

## References
- https://github.com/npm/validate-npm-package-name/issues/135
