### PR TITLE
feat: support environments without require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const { builtinModules: builtins } = require('module')
+const builtins = typeof require !== 'undefined' ? require('module').builtinModules : []
 
 var scopedPackagePattern = new RegExp('^(?:@([^/]+?)[/])?([^/]+?)$')
 var exclusionList = [


### PR DESCRIPTION
Add runtime check for require availability before accessing module.builtinModules, allowing the package to work in non-CommonJS environments like ESM or browsers.

Closes #124
