### PR TITLE
fix: hyphen should be allowed for old packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function validate (name) {
   }
 
   if (name.startsWith('-')) {
-    errors.push('name cannot start with a hyphen')
+    warnings.push('name cannot start with a hyphen')
   }
 
   if (name.match(/^_/)) {

--- a/test/index.js
+++ b/test/index.js
@@ -99,13 +99,13 @@ test('validate-npm-package-name', function () {
 
   assert.deepStrictEqual(validate('-start-with-hyphen'), {
     validForNewPackages: false,
-    validForOldPackages: false,
-    errors: ['name cannot start with a hyphen'] })
+    validForOldPackages: true,
+    warnings: ['name cannot start with a hyphen'] })
 
   assert.deepStrictEqual(validate('--start-with-double-hyphen'), {
     validForNewPackages: false,
-    validForOldPackages: false,
-    errors: ['name cannot start with a hyphen'] })
+    validForOldPackages: true,
+    warnings: ['name cannot start with a hyphen'] })
 
   assert.deepStrictEqual(validate('contain:colons'), {
     validForNewPackages: false,


### PR DESCRIPTION
There are at least [139 old packages that start with a hyphen](https://gist.github.com/ghostdevv/db4f35d83f5904165663dbbbb78ced02), possibly some more as I'm missing 400k packuments from my replica