### PR TITLE
fix: differentiate warnings and errors for leading hyphens in package…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,11 @@ function validate (name) {
   }
 
   if (name.startsWith('-')) {
-    errors.push('name cannot start with a hyphen')
+    if (name === '-') {
+      warnings.push('name cannot start with a hyphen')
+    } else {
+      errors.push('name cannot start with a hyphen')
+    }
   }
 
   if (name.match(/^_/)) {

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,17 @@ test('validate-npm-package-name', function () {
     validForOldPackages: false,
     errors: ['name cannot start with a hyphen'] })
 
+  // Grandfathered single-hyphen package "-" (published before the hyphen rule existed)
+  assert.deepStrictEqual(validate('-'), {
+    validForNewPackages: false,
+    validForOldPackages: true,
+    warnings: ['name cannot start with a hyphen'] })
+
+  assert.deepStrictEqual(validate('-foo'), {
+    validForNewPackages: false,
+    validForOldPackages: false,
+    errors: ['name cannot start with a hyphen'] })
+
   assert.deepStrictEqual(validate('contain:colons'), {
     validForNewPackages: false,
     validForOldPackages: false,


### PR DESCRIPTION
## What / Why

The `-` package is a legitimate, grandfathered package published on the npm registry before the hyphen naming rule existed.

A common real-world use case is silently replacing an unwanted transitive dependency with an empty package. For example, to prevent `moment` from being installed anywhere in the dependency tree:

```json
"overrides": {
  "moment": "npm:-@0.0.1"
}
```

This installs an empty 600B package in place of `moment` without causing install failures. It is a well-known pattern used when a downstream dependency pulls in a package you want to exclude.

PR #156 added a strict check that rejected all names starting with a hyphen as `errors`, which caused `validForOldPackages: false` for `-`. This broke `npm info -- -@0.0.1` and similar workflows in npm@11.8.0.

This fix moves the single-hyphen case (`-`) to `warnings` instead of `errors`, following the existing grandfathered pattern used elsewhere in this package.

### Behavior after this fix

| Package | `validForNewPackages` | `validForOldPackages` |
|---|---|---|
| `-` | `false` | `true` (was `false` before this fix) |
| `-foo` | `false` | `false` |
| `--bar` | `false` | `false` |

## References

Fixes npm/cli#8929